### PR TITLE
Fix resolving files to watch

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -1,24 +1,10 @@
-var minimatch = require('minimatch'),
-    Gaze = require('gaze').Gaze,
+var Gaze = require('gaze').Gaze,
     debounce = require('./debounce'),
     extension = {},
 
     DEFAULT_EVENTS = [ 'added', 'changed', 'deleted' ],
     DEFAULT_DEBOUNCE = 300,
-    DEFAULT_INCLUDE = '**/*';
-
-/**
- * @see {@link https://github.com/isaacs/minimatch}
- * @param {String} path
- */
-extension.filter = function(path) {
-    if (this.exclude && this.exclude.length > 0) {
-        return ! this.exclude.some(function(pattern) {
-            return minimatch(path, pattern);
-        });
-    }
-    return true;
-};
+    DEFAULT_PATTERN = '**/*';
 
 /**
  * Call `console.log` if `silent` option is not set.
@@ -38,7 +24,7 @@ extension.log = function() {
  */
 extension.onMonitorEvent = function(event, path, stat) {
     /* jshint unused:false */
-    if (this.events.indexOf(event) > -1 && this.filter(path)) {
+    if (this.events.indexOf(event) > -1) {
         this.log('FS event <%s> on file "%s"', event, path);
 
         this.restartWorkers();
@@ -66,7 +52,7 @@ extension.initMaster = function(master) {
         }.bind(this)
     );
 
-    this.gaze = new Gaze(this.include);
+    this.gaze = new Gaze(this.patterns);
 
     // register events listeners
     this.events.forEach(function(event) {
@@ -91,8 +77,7 @@ extension.configure = function(config, proc) {
         // don't write events to log if `true`
         this.silent = this.config.get('silent');
 
-        this.include = this.config.get('include', DEFAULT_INCLUDE);
-        this.exclude = this.config.get('exclude', null);
+        this.patterns = this.config.get('patterns', DEFAULT_PATTERN);
 
         this.initMaster(proc);
     }


### PR DESCRIPTION
We should use:
`!<pattern>` to specify exclusion patterns since 'globule' can filter filepaths using such patterns and return to 'gaze' only really need to watching files;
`config.patterns` instead of `config.include` and `config.exclude`, as patterns are processed in order, so inclusion and exclusion order is significant;

Example:

```
"luster-guard" : {
    "patterns" : [
        "**/*.js",
        "!**/node_modules/**"
    ]
 }
```
