### PR TITLE
Fix for node 14+

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -2,7 +2,7 @@ var chokidar = require('chokidar'),
     debounce = require('debounce'),
     extension = {},
 
-    DEFAULT_EVENTS = [ 'add', 'change', 'unlink' ],
+    DEFAULT_EVENTS = ['add', 'change', 'unlink'],
     DEFAULT_DEBOUNCE = 300,
     DEFAULT_INTERVAL = 300,
     DEFAULT_PATTERN = '**/*';

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "readmeFilename": "README.md",
   "dependencies": {
-    "chokidar": "^1.1.0",
+    "chokidar": "^3.5.1",
     "debounce": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "chokidar": "^3.5.1",
-    "debounce": "^1.0.0"
+    "debounce": "^1.2.1"
   },
   "devDependencies": {
-    "eslint": "^1.10.3",
-    "eslint-config-nodules": "^0.1.1",
-    "jscs": "^2.6.0",
+    "eslint": "^7.26.0",
+    "eslint-config-nodules": "^0.4.0",
+    "jscs": "^3.0.7",
     "jscs-preset-nodules": "^0.1.0"
   }
 }


### PR DESCRIPTION
From `npm install`:

> chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.

Updating seems pretty safe, but we can make a new major version just in case :)